### PR TITLE
UTF8 isWideChar, isCombiningChar: fast-bail for low-codepoint text

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -48,7 +48,7 @@
 
 /* ============================ UTF8 utilities ============================== */
 
-static unsigned long wideCharTable[][2] = {
+static unsigned long wideCharTable[][2] = {     /* list in ascending order */
     { 0x1100, 0x115F },
     { 0x231A, 0x231B },
     { 0x2329, 0x232A },
@@ -157,7 +157,7 @@ static unsigned long wideCharTable[][2] = {
 
 static size_t wideCharTableSize = sizeof(wideCharTable) / sizeof(wideCharTable[0]);
 
-static unsigned long combiningCharTable[] = {
+static unsigned long combiningCharTable[] = {   /* list in ascending order */
     0x0300,0x0301,0x0302,0x0303,0x0304,0x0305,0x0306,0x0307,
     0x0308,0x0309,0x030A,0x030B,0x030C,0x030D,0x030E,0x030F,
     0x0310,0x0311,0x0312,0x0313,0x0314,0x0315,0x0316,0x0317,
@@ -378,6 +378,7 @@ static unsigned long combiningCharTableSize = sizeof(combiningCharTable) / sizeo
  */
 static int isWideChar(unsigned long cp) {
     size_t i;
+    if(cp < wideCharTable[0][0]) return 0;  /* fast bail for latin text */
     for (i = 0; i < wideCharTableSize; i++)
         if (wideCharTable[i][0] <= cp && cp <= wideCharTable[i][1]) return 1;
     return 0;
@@ -387,6 +388,7 @@ static int isWideChar(unsigned long cp) {
  */
 static int isCombiningChar(unsigned long cp) {
     size_t i;
+    if(cp < combiningCharTable[0]) return 0;  /* fast bail for latin text */
     for (i = 0; i < combiningCharTableSize; i++)
         if (combiningCharTable[i] == cp) return 1;
     return 0;


### PR DESCRIPTION
I noticed that the UTF8 example.c runs slower and slower the longer the line is.  I profiled and found that `isWideChar` in `utf8.c` was the bottleneck, followed by `isCombiningChar`.  This PR gives those functions a big performance boost, particularly on Latin text, without much effort.

The lowest wide character is U+1100, and the lowest combining character is U+0300.  That leaves a lot of code points, down to U+0000, that can't be wide or combining.  This change tests for those manually so we don't have to search the tables for characters that can't possibly be in those tables.  This does add a small constant to the per-character time for characters above U+0300 or U+1100.  However, my profiling results suggest that time is swamped in the linear table searches.

I also tried using gperf for the `isCombiningChar` table ([branch](https://github.com/cxw42/linenoise/tree/control-c-detect) and that also helped, but this PR gives quite a bit of benefit in a much simpler way.