### PR TITLE
Fixed linenoise.c to compile in C++

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,4 @@
-Tue May 15 16:45:32 UTC 2018
-* Create CHANGELOG
-* Merged PRs #151, #147, #144, #139, #138, #136, #146, #152
-* Merged PRs #135, #130, #127, #119, #117, #112, #133, #126
-* Merged PRs #108, #103, #86, #78, #76, #71
-* Merged PRs #70, #69, #65, #61
-* Integrated the work from yhirose's UTF-8 repo
-
+Sat Jun 3 19:15:32 UTC 2023
+* Fixed naming conflicts with C++ ("new")
+* Added casts from malloc & realloc
+* linenoise.c now compiles and works for C++ projects

--- a/linenoise.c
+++ b/linenoise.c
@@ -539,10 +539,10 @@ void linenoiseAddCompletion(linenoiseCompletions *lc, const char *str) {
     size_t len = strlen(str);
     char *copy, **cvec;
 
-    copy = malloc(len+1);
+    copy = (char*)malloc(len+1);
     if (copy == NULL) return;
     memcpy(copy,str,len+1);
-    cvec = realloc(lc->cvec,sizeof(char*)*(lc->len+1));
+    cvec = (char**)realloc(lc->cvec,sizeof(char*)*(lc->len+1));
     if (cvec == NULL) {
         free(copy);
         return;
@@ -581,11 +581,11 @@ static void abInit(struct abuf *ab) {
 }
 
 static void abAppend(struct abuf *ab, const char *s, unsigned int len) {
-    char *new = realloc(ab->b,ab->len+len);
+    char *new_str = (char*)realloc(ab->b,ab->len+len);
 
-    if (new == NULL) return;
-    memcpy(new+ab->len,s,len);
-    ab->b = new;
+    if (new_str == NULL) return;
+    memcpy(new_str+ab->len,s,len);
+    ab->b = new_str;
     ab->len += len;
 }
 
@@ -1271,7 +1271,7 @@ static char *linenoiseNoTTY(void) {
             char *oldval = line;
             if (maxlen == 0) maxlen = 16;
             maxlen *= 2;
-            line = realloc(line,maxlen);
+            line = (char*)realloc(line,maxlen);
             if (line == NULL) {
                 if (oldval) free(oldval);
                 return NULL;
@@ -1373,7 +1373,7 @@ int linenoiseHistoryAdd(const char *line) {
 
     /* Initialization on first call. */
     if (history == NULL) {
-        history = malloc(sizeof(char*)*history_max_len);
+        history = (char**)malloc(sizeof(char*)*history_max_len);
         if (history == NULL) return 0;
         memset(history,0,(sizeof(char*)*history_max_len));
     }
@@ -1400,14 +1400,14 @@ int linenoiseHistoryAdd(const char *line) {
  * just the latest 'len' elements if the new history length value is smaller
  * than the amount of items already inside the history. */
 int linenoiseHistorySetMaxLen(int len) {
-    char **new;
+    char **new_list;
 
     if (len < 1) return 0;
     if (history) {
         int tocopy = history_len;
 
-        new = malloc(sizeof(char*)*len);
-        if (new == NULL) return 0;
+        new_list = (char**)malloc(sizeof(char*)*len);
+        if (new_list == NULL) return 0;
 
         /* If we can't copy everything, free the elements we'll not use. */
         if (len < tocopy) {
@@ -1416,10 +1416,10 @@ int linenoiseHistorySetMaxLen(int len) {
             for (j = 0; j < tocopy-len; j++) free(history[j]);
             tocopy = len;
         }
-        memset(new,0,sizeof(char*)*len);
-        memcpy(new,history+(history_len-tocopy), sizeof(char*)*tocopy);
+        memset(new_list,0,sizeof(char*)*len);
+        memcpy(new_list,history+(history_len-tocopy), sizeof(char*)*tocopy);
         free(history);
-        history = new;
+        history = new_list;
     }
     history_max_len = len;
     if (history_len > history_max_len)


### PR DESCRIPTION
Fixed casting and name conflict
 
linenoise.c did not cast from malloc nor realloc, which would not let it compile with C++. Fixed. 

There were also a couple of variable named "new" which caused a naming conflict with C++. The names were appended with their type: e.x. "new_str" instead of "new".  Fixed.
                           
These changes allows compiling with C++ code (at least on g++ 11.3.0).
Change Log was updated to reflect the changes also
